### PR TITLE
Adjust paddle and table visuals to white

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ const computerScoreElement = document.getElementById("computer-score");
 
 const TABLE_COLOR = "rgba(0, 0, 0, 0.6)";
 const NET_COLOR = "rgba(255, 255, 255, 0.4)";
-const PADDLE_COLOR = "#00ffa6";
+const PADDLE_COLOR = "#ffffff";
 const BALL_COLOR = "#ffffff";
 
 const MAX_SCORE = 10;

--- a/style.css
+++ b/style.css
@@ -37,7 +37,7 @@ h1 {
 canvas {
   display: block;
   width: 100%;
-  border: 3px solid #00ffa6;
+  border: 3px solid #ffffff;
   border-radius: 10px;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(0, 0, 0, 0.8));
 }


### PR DESCRIPTION
## Summary
- update the canvas border styling to use a white outline
- change the paddle rendering color to white for both players

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd435bb5408329b820c8ac183e57fe